### PR TITLE
ci: :construction_worker: use GitHub App tokens for workflows

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -19,6 +19,7 @@ jobs:
     uses: seedcase-project/.github/.github/workflows/reusable-add-to-project.yml@main
     with:
       board-number: 18
+      app-id: ${{ vars.ADD_TO_BOARD_APP_ID }}
     secrets:
       add-to-board-token: ${{ secrets.ADD_TO_BOARD }}
       gh-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sync-files.yml
+++ b/.github/workflows/sync-files.yml
@@ -9,17 +9,33 @@ jobs:
   sync:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          owner: ${{ github.repository_owner }}
+          app-id: ${{ vars.SYNC_FILES_APP_ID }}
+          private-key: ${{ secrets.SYNC_FILES_TOKEN }}
+
       - name: Checkout Repository
-        uses: actions/checkout@main
+        uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+
+        # Taken from https://github.com/actions/create-github-app-token/
+      - name: Get GitHub App User ID
+        id: get-user-id
+        run: echo "user-id=$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
 
       - name: Run GitHub File Sync
         uses: BetaHuhn/repo-file-sync-action@v1
         with:
-          GH_PAT: ${{ secrets.SYNC_PAT }}
+          GH_INSTALLATION_TOKEN: ${{ steps.app-token.outputs.token }}
           ASSIGNEES: lwjohnst86
           IS_FINE_GRAINED: true
-          GIT_USERNAME: lwjohnst86
-          GIT_EMAIL: lwjohnst@gmail.com
+          GIT_USERNAME: ${{ steps.app-token.outputs.app-slug }}[bot]
+          GIT_EMAIL: ${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com
           COMMIT_PREFIX: "chore(sync): :hammer: "
-          BRANCH_PREFIX: chore
-          TEAM_REVIEWERS: admin
+          COMMIT_EACH_FILE: false
+          BRANCH_PREFIX: chore/data-package-sync


### PR DESCRIPTION
# Description

Aligning with the other template repos, this makes use of the GitHub App token for better security practices.