### PR TITLE
refactor: :recycle: `.gitignore` should be specific to data packages, not Python ones

### DIFF
--- a/template/.gitignore
+++ b/template/.gitignore
@@ -26,40 +26,12 @@ venv
 __pycache__/
 *.py[cod]
 
-# Python packaging and distribution
-.Python
-build/
-develop-eggs/
-dist/
-downloads/
-eggs/
-.eggs/
-lib/
-lib64/
-parts/
-sdist/
-var/
-wheels/
-share/python-wheels/
-*.egg-info/
-.installed.cfg
-*.egg
-MANIFEST
-
-# Python testing and code coverage
-htmlcov/
-.tox/
-.nox/
-.coverage
-.coverage.*
-.cache
-nosetests.xml
-coverage.xml
-*.cover
-*.py,cover
-.hypothesis/
-.pytest_cache/
-cover/
+# Raw data files and folders
+*.parquet
+*.csv
+/data-raw/
+/raw/
+/data/
 
 # MacOS
 .DS_Store
@@ -71,16 +43,11 @@ docs/.quarto/
 *.quarto_ipynb
 *.storage
 
-# Quartodoc
-/docs/reference/
-objects.json
-
 # Website generation
 _site
 _book
 public
 site
-
 
 # Misc files
 *.log


### PR DESCRIPTION
# Description

Remove Python packaging specific ignore files and added data package specific ones. Not sure how the Git LFS will work with this, so it might need changing, especially related to the Parquet files.

This PR needs a quick review.
