### PR TITLE
feat: :sparkles: pre-commit hook to check for conflicts

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,6 +15,8 @@ repos:
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
+      - id: check-merge-conflict
+        args: [--assume-in-merge]
 
   - repo: https://github.com/commitizen-tools/commitizen
     rev: v4.8.3

--- a/template/.pre-commit-config.yaml
+++ b/template/.pre-commit-config.yaml
@@ -15,6 +15,8 @@ repos:
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
+      - id: check-merge-conflict
+        args: [--assume-in-merge]
 
   - repo: https://github.com/commitizen-tools/commitizen
     rev: v4.8.3


### PR DESCRIPTION
# Description

These changes add a hook to check for conflicts. This is most useful when updating the data package from the template.

Closes #96

This PR needs a quick review.

## Checklist

- [x] Ran `just run-all`
