### PR TITLE
refactor: :recycle: limit permissions used in workflow

### DIFF
--- a/template/.github/workflows/add-to-project.yml.jinja
+++ b/template/.github/workflows/add-to-project.yml.jinja
@@ -11,12 +11,14 @@ on:
       - reopened
       - opened
 
-permissions:
-  pull-requests: write
+# Limit token permissions for security
+permissions: read-all
 
 jobs:
   add-to-project:
     uses: seedcase-project/.github/.github/workflows/reusable-add-to-project.yml@main
+    permissions:
+      pull-requests: write
     with:
       board-number: {{ github_board_number }}
       app-id: {{ '${{ vars.ADD_TO_BOARD_APP_ID }}' }}


### PR DESCRIPTION
# Description

Limit default permissions in GitHub Actions workflow.


This PR needs a quick review.

## Checklist

- [x] Ran `just run-all`
