### PR TITLE
feat: :sparkles: increase version in `datapackage.json` file on version update

### DIFF
--- a/template/.cz.toml
+++ b/template/.cz.toml
@@ -5,6 +5,7 @@ version_provider = "uv"
 version_files = [
   "pyproject.toml:version",
   "scripts/properties.py:version"
+  "datapackage.json:version"
 ]
 # Don't regenerate the changelog on every update
 changelog_incremental = true


### PR DESCRIPTION
# Description

When a version update gets triggered, a commit is created with the version updates. So it makes sense to also update the version in the `datapackage.json` file.

This PR needs a quick review.

## Checklist

- [x] Ran `just run-all`
