### PR TITLE
feat: :sparkles: add locked var for copyright year

### DIFF
--- a/copier.yaml
+++ b/copier.yaml
@@ -40,3 +40,8 @@ github_board_number:
     {% if github_board_number and not github_board_number.isdigit() %}
     The board number must be an integer.
     {% endif %}
+
+copyright_year:
+  type: str
+  default: "{{ copyright_year | default('%Y' | strftime) }}"
+  when: false

--- a/template/LICENSE-MIT.md.jinja
+++ b/template/LICENSE-MIT.md.jinja
@@ -1,8 +1,6 @@
 # MIT License
 
-<!-- TODO: Add the year -->
-
-Copyright (c) YEAR {{ package_abbrev }} authors
+Copyright (c) {{ copyright_year }} {{ package_abbrev }} authors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/template/{{ _copier_conf.answers_file }}.jinja
+++ b/template/{{ _copier_conf.answers_file }}.jinja
@@ -1,0 +1,2 @@
+# Changes here will be overwritten by Copier; NEVER EDIT MANUALLY
+{{ dict(_copier_answers, copyright_year=copyright_year) | to_nice_yaml -}}


### PR DESCRIPTION
# Description

This adds a copier var for the copyright year that won't change with updates.

Closes #97, closes #78

This PR needs a quick review.

## Checklist

- [x] Formatted Markdown
- [x] Ran `just run-all`
