### PR TITLE
ci: :construction_worker: switch to using non-Python based website workflow

### DIFF
--- a/.github/workflows/build-website.yml
+++ b/.github/workflows/build-website.yml
@@ -10,8 +10,6 @@ permissions: read-all
 
 jobs:
   build-website:
-    uses: seedcase-project/.github/.github/workflows/reusable-build-docs-with-python.yml@main
+    uses: seedcase-project/.github/.github/workflows/reusable-build-docs.yml@main
     secrets:
       netlify-token: ${{ secrets.NETLIFY_AUTH_TOKEN }}
-      # This is to allow using `gh` CLI
-      github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Description

The only reason to use Python is for the README.qmd file. But we can split that out into a specific recipe in the justfile to update.

This PR needs a quick review.

