### PR TITLE
refactor: :recycle: ignore generated `*_files/` from Quarto

### DIFF
--- a/template/.gitignore
+++ b/template/.gitignore
@@ -41,7 +41,7 @@ __pycache__/
 docs/.quarto/
 *.ipynb
 *.quarto_ipynb
-*.storage
+*_files/
 
 # Website generation
 _site


### PR DESCRIPTION
# Description

These are generated from Quarto and don't need to be tracked.

This PR needs a quick review.