### PR TITLE
fix: :bug: rename `properties` to `package_properties`

### DIFF
--- a/template/.cz.toml
+++ b/template/.cz.toml
@@ -4,7 +4,7 @@ update_changelog_on_bump = true
 version_provider = "uv"
 version_files = [
   "pyproject.toml:version",
-  "scripts/properties.py:version"
+  "scripts/package_properties.py:version",
   "datapackage.json:version"
 ]
 # Don't regenerate the changelog on every update

--- a/template/main.py
+++ b/template/main.py
@@ -1,7 +1,7 @@
 # import polars as pl
 import seedcase_sprout as sp
 
-# from scripts.properties import properties
+# from scripts.package_properties import package_properties
 
 # from scripts.resource_properties import resource_properties
 
@@ -26,12 +26,12 @@ def main():
     # )
 
     ## Save the properties to `datapackage.json`.
-    # sp.write_properties(properties=properties)
+    # sp.write_properties(properties=package_properties)
 
     ## README
 
     ## Create the README text for the data package.
-    # readme_text = sp.as_readme_text(properties)
+    # readme_text = sp.as_readme_text(package_properties)
     ## Write the README text to a `README.md` file.
     # sp.write_file(readme_text, package_path.readme())
 


### PR DESCRIPTION
# Description

This PR renames `properties` to `package_properties` to match what was done in https://github.com/seedcase-project/seedcase-sprout/pull/1484.

This PR needs a quick review.

## Checklist

- [x] Formatted Markdown
- [x] Ran `just run-all`
