### PR TITLE
fix: :bug: post-copy tasks should run in sequence, not be dependent

### DIFF
--- a/copier.yaml
+++ b/copier.yaml
@@ -3,7 +3,7 @@ _subdirectory: template
 # Post-copy commands:
 _tasks:
   # Only run these commands when copying the template
-  - command: "git init -b main && uv add --dev pre-commit commitizen ruff typos && uv add polars seedcase-sprout"
+  - command: "git init -b main; uv add --dev pre-commit commitizen ruff typos; uv add polars seedcase-sprout"
     when: "{{ _copier_operation == 'copy' }}"
 
 # Message to show after generating or regenerating the project successfully


### PR DESCRIPTION
# Description

The use of `&&` means "only run next if the current succeeds. But we don't really want that, we want them to run, regardless of if the previous ran.

This PR needs a quick review.

## Checklist

- [x] Ran `just run-all`
