### PR TITLE
fix: :bug: when bumping versions, we still want the website updated too

### DIFF
--- a/.cz.toml
+++ b/.cz.toml
@@ -1,6 +1,6 @@
 [tool.commitizen]
 version = "0.11.0"
-bump_message = "build(version): :bookmark: update version from $current_version to $new_version [skip ci]"
+bump_message = "build(version): :bookmark: update version from $current_version to $new_version"
 version_schema = "semver"
 version_provider = "commitizen"
 update_changelog_on_bump = true

--- a/template/.cz.toml
+++ b/template/.cz.toml
@@ -1,5 +1,5 @@
 [tool.commitizen]
-bump_message = "build(version): :bookmark: update version from $current_version to $new_version [skip ci]"
+bump_message = "build(version): :bookmark: update version from $current_version to $new_version"
 update_changelog_on_bump = true
 version_provider = "uv"
 version_files = [


### PR DESCRIPTION
# Description

The `[skip ci]` removes the chance for the website re-generate with the latest version update changes (e.g. CHANGELOG).

This PR needs a quick review.

## Checklist

- [x] Ran `just run-all`
