### PR TITLE
refactor: :construction_worker: use bash instead of zsh

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,8 +21,8 @@ jobs:
         with:
           enable-cache: true
 
-      - name: Install justfile and zsh
-        run: sudo apt install -y just zsh
+      - name: Install justfile
+        run: sudo apt install -y just
 
       - name: Set Git user
         run: |

--- a/justfile
+++ b/justfile
@@ -15,14 +15,15 @@ install-precommit:
 
 # Check the commit messages on the current branch that are not on the main branch
 check-commits:
-  #!/bin/zsh
+  #!/usr/bin/env bash
   branch_name=$(git rev-parse --abbrev-ref HEAD)
   number_of_commits=$(git rev-list --count HEAD ^main)
   if [[ ${branch_name} != "main" && ${number_of_commits} -gt 0 ]]
   then
+    # If issue happens, try `uv tool update-shell`
     uvx --from commitizen cz check --rev-range main..HEAD
   else
-    echo "On `main` or current branch doesn't have any commits."
+    echo "On 'main' or current branch doesn't have any commits."
   fi
 
 # Check for spelling errors in files
@@ -31,7 +32,7 @@ check-spelling:
 
 # Test and check that a data package can be created from the template
 test:
-  #!/bin/zsh
+  #!/usr/bin/env bash
   test_name="test-data-package"
   test_dir="$(pwd)/_temp/$test_name"
   template_dir="$(pwd)"
@@ -88,7 +89,6 @@ test:
 
 # Clean up any leftover and temporary build files
 cleanup:
-  #!/bin/zsh
   rm -rf _temp
 
 # Build the website using Quarto

--- a/template/justfile
+++ b/template/justfile
@@ -30,16 +30,17 @@ format-python:
   uv run ruff check --fix .
   uv run ruff format .
 
-# Run checks on commits with non-main branches
+# Check the commit messages on the current branch that are not on the main branch
 check-commits:
-  #!/bin/zsh
+  #!/usr/bin/env bash
   branch_name=$(git rev-parse --abbrev-ref HEAD)
-  number_of_commits=$(git rev-list --count HEAD ^$branch_name)
+  number_of_commits=$(git rev-list --count HEAD ^main)
   if [[ ${branch_name} != "main" && ${number_of_commits} -gt 0 ]]
   then
-    uv run cz check --rev-range main..HEAD
+    # If issue happens, try `uv tool update-shell`
+    uvx --from commitizen cz check --rev-range main..HEAD
   else
-    echo "Not on main or haven't committed yet."
+    echo "On 'main' or current branch doesn't have any commits."
   fi
 
 # Check for spelling errors in files


### PR DESCRIPTION
# Description

This makes just recipes use bash instead of zsh.
Copied from https://github.com/seedcase-project/template-website/pull/40

Closes #146 

This PR needs a quick review.

## Checklist

- [x] Formatted Markdown
- [x] Ran `just run-all`
