### PR TITLE
ci: :construction_worker: use `reusable-test-copier` workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,23 +11,4 @@ permissions: read-all
 
 jobs:
   test-copier:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
-
-      - name: Set up uv
-        uses: astral-sh/setup-uv@d9e0f98d3fc6adb07d1e3d37f3043649ddad06a1
-        with:
-          enable-cache: true
-
-      - name: Install justfile and zsh
-        run: sudo apt install -y just zsh
-
-      - name: Set Git user
-        run: |
-          git config --global user.name "GitHub Actions"
-          git config --global user.email "fake@example.com"
-
-      - name: Test and check template creation
-        run: just test
+    uses: seedcase-project/.github/.github/workflows/reusable-test-copier.yml@main

--- a/justfile
+++ b/justfile
@@ -1,6 +1,8 @@
 @_default:
     just --list --unsorted
 
+@_tests: test
+
 # Run all build-related recipes in the justfile
 run-all: check-spelling check-commits test build-website build-readme
 


### PR DESCRIPTION
# Description

This PR switches over to the `reusable-test-copier` workflow.
Depends on https://github.com/seedcase-project/.github/pull/294 and #150 

Closes #65 

This PR needs a quick review.

## Checklist

- [x] Formatted Markdown
- [x] Ran `just run-all`
