### PR TITLE
fix: :bug: exclude `justfile` in the `list-todos` recipe

### DIFF
--- a/template/justfile
+++ b/template/justfile
@@ -6,7 +6,7 @@ run-all: install-deps format-python check-python check-spelling check-commits bu
 
 # List all TODO items in the repository
 list-todos:
-  grep -R -n --exclude="*.code-snippets" "TODO" *
+  grep -R -n --exclude="*.code-snippets" --exclude="justfile" "TODO" *
 
 # Install the pre-commit hooks
 install-precommit:


### PR DESCRIPTION
# Description

Otherwise the recipe flags both the comment and the recipe itself in the `justfile` as TODO items.

E.g., in `example-rhesus-monkeys`: 

<img width="459" height="175" alt="Screenshot 2025-08-19 at 15 39 48" src="https://github.com/user-attachments/assets/f5fdb5a4-6b34-4543-9ff5-682ebd15f861" />

This PR needs a quick review.

## Checklist

- [X] Ran `just run-all`
