### PR TITLE
fix: :bug: use website in quarto config

### DIFF
--- a/template/.pre-commit-config.yaml
+++ b/template/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
         args: [--assume-in-merge]
 
   - repo: https://github.com/commitizen-tools/commitizen
-    rev: v4.13.9
+    rev: v4.13.10
     hooks:
       - id: commitizen
 
@@ -27,11 +27,11 @@ repos:
   # sub-packages, which confuses pre-commit when it tries to find the latest
   # version
   - repo: https://github.com/adhtruong/mirrors-typos
-    rev: v1.45.0
+    rev: v1.45.1
     hooks:
       - id: typos
 
   - repo: https://github.com/rvben/rumdl-pre-commit
-    rev: v0.1.58
+    rev: v0.1.76
     hooks:
       - id: rumdl-fmt # Auto-format

--- a/template/README.md.jinja
+++ b/template/README.md.jinja
@@ -1,3 +1,14 @@
 # {{ github_repo }}
 
 <!-- TODO: Add a short description of the package and how to contribute. -->
+
+## Licensing
+
+Code in this project is licensed under the [MIT License](LICENSE-MIT.md).
+{% if cc0_license -%}
+Data in this project is licensed under the [CC0 License](LICENSE.md).
+{%- endif %}
+
+## Changelog
+
+For a list of changes, see our [changelog](CHANGELOG.md) page.

--- a/template/_quarto.yml.jinja
+++ b/template/_quarto.yml.jinja
@@ -2,41 +2,29 @@ project:
   # TODO: Change to correct project type if using extensions
   type: website
 
-book:
+
+website:
   title: "TODO: Set the title of the website"
   # TODO: Set the URL of the website
   site-url: ""
   repo-url: "https://github.com/{{ github_repo_spec }}"
-  author:
-    - name: "{{ author_given_name }} {{ author_family_name }}"
-      affiliation: "TODO: Fill in your affiliation"
-      orcid: "TODO: Fill in your ORCID"
   # TODO: Set favicon if relevant.
   # favicon: ""
-  repo-branch: main
-  repo-actions: [issue, edit, source]
-  search:
-    location: navbar
-    type: textbox
-  chapters:
-    - index.qmd
-  #  - part: "Sections"
-  #    chapters:
-  #    - path/to/file.qmd
-  # appendices:
-  #  - path/to/file.qmd
-  tools:
-    - icon: github
-      href: "https://github.com/{{ github_repo_spec }}"
-      aria-label: "GitHub icon: Source repository"
-  page-footer:
-    center:
-      - text: "Code under MIT License"
-        href: "LICENSE-MIT.md"
-      {% if cc0_license -%}
-      - text: "Data under CC0 License"
-        href: "LICENSE.md"
-      {%- endif %}
+  navbar:
+    # TODO: Add logo and logo-alt
+    logo: ""
+    logo-alt: ""
+    pinned: true
+    left:
+      - text: "Welcome"
+        href: index.qmd
+    tools:
+      - icon: github
+        href: "https://github.com/{{ github_repo_spec }}"
+        aria-label: "GitHub icon: Source repository"
+  sidebar:
+    contents:
+      - index.qmd
 
 format:
   # TODO: Use Quarto extension if available
@@ -45,3 +33,6 @@ format:
       # TODO: Choose a different theme if desired
       - litera
       - custom-styles.scss
+    # TODO: Uncomment if using the goatcounter website visitor counter
+    # include-before-body:
+      # - "includes/site-counter.html"


### PR DESCRIPTION
# Description

When we moved to `quarto-resource-tables`, I didn't update the quarto config fully to website.

How it looks without a custom theme:
<img width="1485" height="667" alt="Screenshot 2026-04-23 at 11 29 39" src="https://github.com/user-attachments/assets/f91f7e27-f48e-4cc2-a781-5fba5f2a957f" />
<img width="1482" height="736" alt="Screenshot 2026-04-23 at 11 29 54" src="https://github.com/user-attachments/assets/6ede0dea-4f79-49fe-8bfc-45ff27875da4" />

The sidebar on the left is a bit weird and the resources table is too wide. What would be the place to fix these?


This PR needs a thorough review.

## Checklist

- [x] Ran `just run-all`
