### PR TITLE
refactor: :recycle: generate data package pages in docs

### DIFF
--- a/template/.flower.toml
+++ b/template/.flower.toml
@@ -1,2 +1,2 @@
 style = "quarto-resource-tables"
-output-dir = "."
+output-dir = "docs"

--- a/template/.gitignore
+++ b/template/.gitignore
@@ -48,6 +48,8 @@ _site
 _book
 public
 site
+docs/resources
+docs/index.qmd
 
 # Misc files
 *.log

--- a/template/_quarto.yml.jinja
+++ b/template/_quarto.yml.jinja
@@ -16,8 +16,10 @@ website:
     logo-alt: ""
     pinned: true
     left:
-      - text: "Welcome"
+      - text: "Overview"
         href: index.qmd
+      - text: "Data Package"
+        href: docs/index.qmd
     tools:
       - icon: github
         href: "https://github.com/{{ github_repo_spec }}"
@@ -25,6 +27,7 @@ website:
   sidebar:
     contents:
       - index.qmd
+      - docs/index.qmd
 
 format:
   # TODO: Use Quarto extension if available

--- a/template/index.qmd
+++ b/template/index.qmd
@@ -1,0 +1,3 @@
+# Overview
+
+<!-- TODO: Add a short description of the package and how to contribute. -->


### PR DESCRIPTION
# Description

This PR generates the Data Package pages in a `docs` folder and adds an index page for the repo/project as a whole.

This PR needs a quick review.

## Checklist

- [x] Ran `just run-all`
