### PR TITLE
ci: 🐛 only check commits from latest tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,6 +55,7 @@ jobs:
         uses: cocogitto/cocogitto-action@9a9fe03b31c47444290c0d7f9b1ee1b44ee13f20 # v4.1.0
         with:
           command: check
+          args: --from-latest-tag
 
       # Install uv to use git-cliff and rumdl
       - name: Set up uv


### PR DESCRIPTION
# Description

The first commit was not a Conventional Commit, so check caused an error. This only checks from the latest tag.

Needs no review.
