### PR TITLE
refactor: 🔧 include more URLs in `pyproject.toml`

### DIFF
--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -24,8 +24,11 @@ license-files = ["LICENSE-MIT.md"]
 requires-python = ">=3.12"
 
 [project.urls]
-issues = "https://github.com/{{ github_repo_spec }}/issues"
+# TODO: Add URLs relevant to the project.
+homepage = ""
 repository = "https://github.com/{{ github_repo_spec }}"
+issues = "https://github.com/{{ github_repo_spec }}/issues"
+changelog = "https://github.com/{{ github_repo_spec }}/blob/main/CHANGELOG.md"
 
 [tool.ruff]
 extend = ".config/ruff.toml"


### PR DESCRIPTION
# Description

Just expands to include other URLs.

Needs no review.

## Checklist

- [x] Ran `just run-all`
