### PR TITLE
fix: 🔧 use lowercase for true in `pyproject.toml`

### DIFF
--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -35,4 +35,4 @@ extend = ".config/ruff.toml"
 
 [tool.mypy]
 python_version = 3.12
-strict = True
+strict = true


### PR DESCRIPTION
# Description

true and false are lowercase in TOML.

Needs no review.

## Checklist

- [x] Ran `just run-all`
